### PR TITLE
fix: Update docker-compose environment vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,9 @@ services:
     ports:
       - "9092"
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: 192.168.99.100
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
This will fix the following error when using the console producer:

```bash
WARN Error while fetching metadata with correlation id 39 :  {4-3-16-topic1=LEADER_NOT_AVAILABLE} (org.apache.kafka.clients.NetworkClient)
```

Details in the below thread:

https://stackoverflow.com/questions/35788697/leader-not-available-kafka-in-console-producer

`KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1` Allows for a single broker to be used.